### PR TITLE
Include react and reactdom as dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "prettier": "^2.8.0",
     "typescript": "^4.6.4",
     "vite": "^3.2.3",
-    "vite-plugin-dts": "^1.7.1"
+    "vite-plugin-dts": "^1.7.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }


### PR DESCRIPTION
Package will use the react version used application wide, to enforce the required version we can supply react and react-dom as `peerDedependencies` if need be